### PR TITLE
Update dependencies to support latest Android Studio version (Electric Eel 2022.1.1 Patch 2)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,12 +5,13 @@ plugins {
 }
 
 android {
-    compileSdk 31
+    namespace 'com.skooldio.android.debugging.publishing.workshop.pomodoro'
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.skooldio.android.debugging.publishing.workshop.pomodoro"
         minSdk 21
-        targetSdk 31
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 
@@ -37,11 +38,11 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'com.google.android.material:material:1.5.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.8.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.skooldio.android.debugging.publishing.workshop.pomodoro">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:name=".PomodoroApplication"

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.1.0' apply false
-    id 'com.android.library' version '7.1.0' apply false
-    id 'org.jetbrains.kotlin.android' version '1.5.30' apply false
+    id 'com.android.application' version '7.4.2' apply false
+    id 'com.android.library' version '7.4.2' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.21' apply false
 }
 
 task clean(type: Delete) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Feb 21 02:49:23 ICT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
* Gradle 7.6.1
* Android Gradle Plugin 7.4.2
* Kotlin 1.7.21
* Target & Compile SDK v33
* Move package in AndroidManifest to namespace in `build.gradle`
* Update library
  * AndroidX Core KTX 1.9.0
  * AndroidX AppCompat 1.6.1
  * Material Design 1.8.0
  * AndroidX ConstraintLayout 2.1.4
  * AndroidX JUnit Ext 1.1.5
  * AndroidX Espresso 3.5.1